### PR TITLE
Add colors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 > a danker, more neon theme for anywhere you view code
 
+## The Grays
+| Name | Hex | RGBA | |
+| ---- | --- | ---- |-|
+| Deep Dark | `#191b2a` | `25, 27, 42`| ![deep dark](https://user-images.githubusercontent.com/2363236/51059291-b1f0eb80-15b9-11e9-8891-55a3381171b6.png) |
+| Shallow Dark | `#1d1f30` | `29, 31, 48`| ![shallow dark](https://user-images.githubusercontent.com/2363236/51059298-b1f0eb80-15b9-11e9-90ef-3957562bba07.png) |
+| Deep Blue | `#2a2d46` | `42, 45, 70`| ![deep blue](https://user-images.githubusercontent.com/2363236/51059294-b1f0eb80-15b9-11e9-884b-2c10806be584.png) |
+| Shallow Blue | `#3c4367` | `60, 67, 103`| ![shallow blue](https://user-images.githubusercontent.com/2363236/51059297-b1f0eb80-15b9-11e9-80f1-0c97daa5d107.png) |
+| Dank Blue | `#4f5987` | `79, 89, 135`| ![dank blue](https://user-images.githubusercontent.com/2363236/51059293-b1f0eb80-15b9-11e9-9b24-42031d650bae.png) |
+| Gunmetal | `#656fa4` | `101, 111, 164` | ![gunmetal](https://user-images.githubusercontent.com/2363236/51059299-b1f0eb80-15b9-11e9-951a-11f0cfd1f7fc.png) |
+| Shark Blue | `#858db7` | `133, 141, 183`| ![shark blue](https://user-images.githubusercontent.com/2363236/51059295-b1f0eb80-15b9-11e9-866e-72f4a4e6b389.png) |
+| Ocean Blue | `#a5abca` | `165, 171, 202`| ![ocean blue](https://user-images.githubusercontent.com/2363236/51059290-b1585500-15b9-11e9-9992-c82e032ff37b.png) |
+| Tooth Gray  | `#eff0f6` | `239, 240, 246`| ![tooth gray](https://user-images.githubusercontent.com/2363236/51059296-b1f0eb80-15b9-11e9-8852-0ab036fdb6e0.png) |
+
+## The Colors
+
+| Name | Hex | RGBA | | Dark Hex | Dark RGBA | |
+| ---- | --- | ---- |-| ---------- | ----------- |-|
+|  | `#ff476e` | ``| ![red](https://user-images.githubusercontent.com/2363236/51060566-229a0700-15be-11e9-9bac-4bce38f5b104.png) | `#ac3756` | ``| ![dark red](https://user-images.githubusercontent.com/2363236/51060561-22017080-15be-11e9-8327-2b6ebf5e4772.png) |
+| Dank Green | `#39ffba` | ``| ![green](https://user-images.githubusercontent.com/2363236/51060565-229a0700-15be-11e9-9a3b-54fc422891e5.png) | `#2dad86` | ``| ![dark green](https://user-images.githubusercontent.com/2363236/51060560-22017080-15be-11e9-9d6f-9e14769fe15b.png) |
+|  | `#ffee7a` | ``| ![yellow](https://user-images.githubusercontent.com/2363236/51060569-229a0700-15be-11e9-9265-b84d1f804640.png) | `#ffca7a` | ``| ![dark yellow](https://user-images.githubusercontent.com/2363236/51060564-229a0700-15be-11e9-8e69-715cc9bddb3f.png) |
+|  | `#94bfff` | ``| ![blue](https://user-images.githubusercontent.com/2363236/51060557-22017080-15be-11e9-8351-7cede1105c8f.png) | `#7496cc` | ``| ![dark blue](https://user-images.githubusercontent.com/2363236/51060559-22017080-15be-11e9-9411-8fe933b74c82.png) |
+|  | `#f1b3f1` | ``| ![violet](https://user-images.githubusercontent.com/2363236/51060567-229a0700-15be-11e9-9618-b98d218533d2.png) | `#a37ca9` | ``| ![dark violet](https://user-images.githubusercontent.com/2363236/51060563-229a0700-15be-11e9-9698-fa559fbc32e1.png) |
+|  | `#01f7f7` | ``| ![cyan](https://user-images.githubusercontent.com/2363236/51060558-22017080-15be-11e9-8b0e-6932ccbbca22.png) | `#01a8ad` | ``| ![dark cyan](https://user-images.githubusercontent.com/2363236/51060562-229a0700-15be-11e9-8736-ea769eebde50.png) |
+
 ## Installing for your editor
 
 To install Dank Neon for your favorite editor, [visit the homepage](http://dankneon.com) and find your editor in the listing. (Don't see your editor? [Create a theme today!](CONTRIBUTING.md))

--- a/README.md
+++ b/README.md
@@ -3,28 +3,39 @@
 > a danker, more neon theme for anywhere you view code
 
 ## The Grays
-| Name | Hex | RGBA | |
-| ---- | --- | ---- |-|
-| Deep Dark | `#191b2a` | `25, 27, 42`| ![deep dark](https://user-images.githubusercontent.com/2363236/51059291-b1f0eb80-15b9-11e9-8891-55a3381171b6.png) |
-| Shallow Dark | `#1d1f30` | `29, 31, 48`| ![shallow dark](https://user-images.githubusercontent.com/2363236/51059298-b1f0eb80-15b9-11e9-90ef-3957562bba07.png) |
-| Deep Blue | `#2a2d46` | `42, 45, 70`| ![deep blue](https://user-images.githubusercontent.com/2363236/51059294-b1f0eb80-15b9-11e9-884b-2c10806be584.png) |
-| Shallow Blue | `#3c4367` | `60, 67, 103`| ![shallow blue](https://user-images.githubusercontent.com/2363236/51059297-b1f0eb80-15b9-11e9-80f1-0c97daa5d107.png) |
-| Dank Blue | `#4f5987` | `79, 89, 135`| ![dank blue](https://user-images.githubusercontent.com/2363236/51059293-b1f0eb80-15b9-11e9-9b24-42031d650bae.png) |
-| Gunmetal | `#656fa4` | `101, 111, 164` | ![gunmetal](https://user-images.githubusercontent.com/2363236/51059299-b1f0eb80-15b9-11e9-951a-11f0cfd1f7fc.png) |
-| Shark Blue | `#858db7` | `133, 141, 183`| ![shark blue](https://user-images.githubusercontent.com/2363236/51059295-b1f0eb80-15b9-11e9-866e-72f4a4e6b389.png) |
-| Ocean Blue | `#a5abca` | `165, 171, 202`| ![ocean blue](https://user-images.githubusercontent.com/2363236/51059290-b1585500-15b9-11e9-9992-c82e032ff37b.png) |
-| Tooth Gray  | `#eff0f6` | `239, 240, 246`| ![tooth gray](https://user-images.githubusercontent.com/2363236/51059296-b1f0eb80-15b9-11e9-8852-0ab036fdb6e0.png) |
+
+| Name         | Hex       | RGBA            |                                                                                                                      |
+| ------------ | --------- | --------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Deep Dark    | `#191b2a` | `25, 27, 42`    | ![deep dark](https://user-images.githubusercontent.com/2363236/51059291-b1f0eb80-15b9-11e9-8891-55a3381171b6.png)    |
+| Shallow Dark | `#1d1f30` | `29, 31, 48`    | ![shallow dark](https://user-images.githubusercontent.com/2363236/51059298-b1f0eb80-15b9-11e9-90ef-3957562bba07.png) |
+| Deep Blue    | `#2a2d46` | `42, 45, 70`    | ![deep blue](https://user-images.githubusercontent.com/2363236/51059294-b1f0eb80-15b9-11e9-884b-2c10806be584.png)    |
+| Shallow Blue | `#3c4367` | `60, 67, 103`   | ![shallow blue](https://user-images.githubusercontent.com/2363236/51059297-b1f0eb80-15b9-11e9-80f1-0c97daa5d107.png) |
+| Dank Blue    | `#4f5987` | `79, 89, 135`   | ![dank blue](https://user-images.githubusercontent.com/2363236/51059293-b1f0eb80-15b9-11e9-9b24-42031d650bae.png)    |
+| Gunmetal     | `#656fa4` | `101, 111, 164` | ![gunmetal](https://user-images.githubusercontent.com/2363236/51059299-b1f0eb80-15b9-11e9-951a-11f0cfd1f7fc.png)     |
+| Shark Blue   | `#858db7` | `133, 141, 183` | ![shark blue](https://user-images.githubusercontent.com/2363236/51059295-b1f0eb80-15b9-11e9-866e-72f4a4e6b389.png)   |
+| Ocean Blue   | `#a5abca` | `165, 171, 202` | ![ocean blue](https://user-images.githubusercontent.com/2363236/51059290-b1585500-15b9-11e9-9992-c82e032ff37b.png)   |
+| Tooth Gray   | `#eff0f6` | `239, 240, 246` | ![tooth gray](https://user-images.githubusercontent.com/2363236/51059296-b1f0eb80-15b9-11e9-8852-0ab036fdb6e0.png)   |
 
 ## The Colors
 
-| Name | Hex | RGBA | | Dark Hex | Dark RGBA | |
-| ---- | --- | ---- |-| ---------- | ----------- |-|
-|  | `#ff476e` | ``| ![red](https://user-images.githubusercontent.com/2363236/51060566-229a0700-15be-11e9-9bac-4bce38f5b104.png) | `#ac3756` | ``| ![dark red](https://user-images.githubusercontent.com/2363236/51060561-22017080-15be-11e9-8327-2b6ebf5e4772.png) |
-| Dank Green | `#39ffba` | ``| ![green](https://user-images.githubusercontent.com/2363236/51060565-229a0700-15be-11e9-9a3b-54fc422891e5.png) | `#2dad86` | ``| ![dark green](https://user-images.githubusercontent.com/2363236/51060560-22017080-15be-11e9-9d6f-9e14769fe15b.png) |
-|  | `#ffee7a` | ``| ![yellow](https://user-images.githubusercontent.com/2363236/51060569-229a0700-15be-11e9-9265-b84d1f804640.png) | `#ffca7a` | ``| ![dark yellow](https://user-images.githubusercontent.com/2363236/51060564-229a0700-15be-11e9-8e69-715cc9bddb3f.png) |
-|  | `#94bfff` | ``| ![blue](https://user-images.githubusercontent.com/2363236/51060557-22017080-15be-11e9-8351-7cede1105c8f.png) | `#7496cc` | ``| ![dark blue](https://user-images.githubusercontent.com/2363236/51060559-22017080-15be-11e9-9411-8fe933b74c82.png) |
-|  | `#f1b3f1` | ``| ![violet](https://user-images.githubusercontent.com/2363236/51060567-229a0700-15be-11e9-9618-b98d218533d2.png) | `#a37ca9` | ``| ![dark violet](https://user-images.githubusercontent.com/2363236/51060563-229a0700-15be-11e9-9698-fa559fbc32e1.png) |
-|  | `#01f7f7` | ``| ![cyan](https://user-images.githubusercontent.com/2363236/51060558-22017080-15be-11e9-8b0e-6932ccbbca22.png) | `#01a8ad` | ``| ![dark cyan](https://user-images.githubusercontent.com/2363236/51060562-229a0700-15be-11e9-8736-ea769eebde50.png) |
+| Name          | Hex       | RGBA            |                                                                                                                | Dark Hex  | Dark RGBA       |                                                                                                                     |
+| ------------- | --------- | --------------- | -------------------------------------------------------------------------------------------------------------- | --------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Neon Red      | `#ff476e` | `255, 71, 110`  | ![red](https://user-images.githubusercontent.com/2363236/51060566-229a0700-15be-11e9-9bac-4bce38f5b104.png)    | `#ac3756` | `172, 55, 86`   | ![dark red](https://user-images.githubusercontent.com/2363236/51060561-22017080-15be-11e9-8327-2b6ebf5e4772.png)    |
+| Dank Green    | `#39ffba` | `57, 255, 186`  | ![green](https://user-images.githubusercontent.com/2363236/51060565-229a0700-15be-11e9-9a3b-54fc422891e5.png)  | `#2dad86` | `45, 173, 134`  | ![dark green](https://user-images.githubusercontent.com/2363236/51060560-22017080-15be-11e9-9d6f-9e14769fe15b.png)  |
+| Sunny Yellow  | `#ffee7a` | `255, 238, 122` | ![yellow](https://user-images.githubusercontent.com/2363236/51060569-229a0700-15be-11e9-9265-b84d1f804640.png) | `#ffca7a` | `255, 202, 122` | ![dark yellow](https://user-images.githubusercontent.com/2363236/51060564-229a0700-15be-11e9-8e69-715cc9bddb3f.png) |
+| Miami Sky     | `#94bfff` | `148, 191, 255` | ![blue](https://user-images.githubusercontent.com/2363236/51060557-22017080-15be-11e9-8351-7cede1105c8f.png)   | `#7496cc` | `116, 150, 204` | ![dark blue](https://user-images.githubusercontent.com/2363236/51060559-22017080-15be-11e9-9411-8fe933b74c82.png)   |
+| Vice Purple   | `#f1b3f1` | `241, 179, 241` | ![violet](https://user-images.githubusercontent.com/2363236/51060567-229a0700-15be-11e9-9618-b98d218533d2.png) | `#a37ca9` | `163, 124, 169` | ![dark violet](https://user-images.githubusercontent.com/2363236/51060563-229a0700-15be-11e9-9698-fa559fbc32e1.png) |
+| Too Cool Teal | `#01f7f7` | `1, 247, 247`   | ![cyan](https://user-images.githubusercontent.com/2363236/51060558-22017080-15be-11e9-8b0e-6932ccbbca22.png)   | `#01a8ad` | `1, 168, 173`   | ![dark cyan](https://user-images.githubusercontent.com/2363236/51060562-229a0700-15be-11e9-8736-ea769eebde50.png)   |
+
+## Accessibility
+
+Dank Neon is designed to be easy on the eyes and accessible for everyone.
+
+The bright colors all pass WCAG AA color contrast guidelines when placed on the two darkest gray backgrond colors (Deep Dark & Shallow Dark).
+
+Dark colors should be used sparingly as they don't meet standards well.
+
+Color's were tested with [Accessible Colors](http://accessible-colors.com/)
 
 ## Installing for your editor
 
@@ -42,4 +53,4 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 ## Acknowledgments
 
-* Dank Neon was started by [@jpetrucciani](https://github.com/jpetrucciani) and [@wuz](https://github.com/wuz)
+- Dank Neon was started by [@jpetrucciani](https://github.com/jpetrucciani) and [@wuz](https://github.com/wuz)


### PR DESCRIPTION
This PR adds the Dank Neon colors to the meta repo and highlights the accessibility guidelines for future Dank Neon projects.